### PR TITLE
Adding Data field to searchableColumns to fix the "application search"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,8 @@ v28.0.00
         Finance: fixed bulk exporting invoice fees for Pending invoices
         Form Groups: fixed Year Group Summary list when looking at non-current school years
         Timetable: fixed permission checking before displaying user status info in View Timetables list
+        Fixing the search results on the Admission module (Manage Application).
+
     
 v27.0.01
 --------

--- a/src/Domain/Admissions/AdmissionsApplicationGateway.php
+++ b/src/Domain/Admissions/AdmissionsApplicationGateway.php
@@ -38,7 +38,7 @@ class AdmissionsApplicationGateway extends QueryableGateway
     private static $tableName = 'gibbonAdmissionsApplication';
     private static $primaryKey = 'gibbonAdmissionsApplicationID';
 
-    private static $searchableColumns = ['owner', 'gibbonAdmissionsApplicationID'];
+    private static $searchableColumns = ['owner', 'gibbonAdmissionsApplicationID', 'data'];
 
     /**
      * @param QueryCriteria $criteria


### PR DESCRIPTION
Adding Data field to searchableColumns to fix the "application search". 
The problem is, 
on [Admissions > Manage Applications], the search is not showing applications when searching by student name, or last name,...

**How Has This Been Tested?**
I tested on my copy of Gibbon. it works for the data available in the 'Data' column. 
